### PR TITLE
Switch Fed.Exp. Lens to main tag

### DIFF
--- a/federated-search/eucaim/lens.yml
+++ b/federated-search/eucaim/lens.yml
@@ -53,7 +53,7 @@ spec:
             cpu: 1
             memory: 2Gi
         imagePullPolicy: Always
-        image: docker.verbis.dkfz.de/eucaim/lens:eucaim
+        image: samply/eucaim-frontend:main
 
 ---
 


### PR DESCRIPTION
This PR switches the image of the Lens frontend for federated exploration to the stable `main` branch